### PR TITLE
fix: multipart on empty lists

### DIFF
--- a/aiogqlc/utils.py
+++ b/aiogqlc/utils.py
@@ -7,7 +7,10 @@ def is_file_like(variable: Any) -> bool:
 
 
 def is_file_list_like(variable: Any) -> bool:
-    return isinstance(variable, list) and all(isinstance(item, io.IOBase) for item in variable)
+    # True if variable is a non-empty list of io.IOBase instances
+    return isinstance(variable, list) \
+        and variable \
+        and all(isinstance(item, io.IOBase) for item in variable)
 
 
 def is_file_variable(variable: Any) -> bool:


### PR DESCRIPTION
- When variables is an empty list:
  - ![image](https://user-images.githubusercontent.com/47480384/85328794-f6630500-b496-11ea-8813-6f0d17860222.png)
  - The utils module consider it a file-like-list variable and performs a multi-part request: 
  - ![image](https://user-images.githubusercontent.com/47480384/85328844-1397d380-b497-11ea-8626-331df73bacf0.png)
  - ![image](https://user-images.githubusercontent.com/47480384/85328889-290cfd80-b497-11ea-8bbd-06517c29ea20.png)
  - ![image](https://user-images.githubusercontent.com/47480384/85328958-404beb00-b497-11ea-91b0-289437aeec96.png)
- That is fine, however graphql servers based on graphene (which are the big majority) do not support this kind of requests out-of-the box.
- This causes empty list variables to return unsupported media type errors, whitout need:
  - ![image](https://user-images.githubusercontent.com/47480384/85329126-8acd6780-b497-11ea-9e41-a174501a559e.png)
- If we make sure that we only make multipart uploads when there is at least 1 file object in a variable (or list variable) then we save a lot of users from getting into trouble, without hurting performance or risking backward incompatible changes :)