### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,14 +15,13 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
 [options]
 zip_safe=False
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     aiohttp >= 3.6.0
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{36,37,38,39}
+	py{37,38,39}
 	black,flake8
 
 [testenv]


### PR DESCRIPTION
There are two reasons we want to drop support for python 3.6 in the next version:

- Python 3.6 will end receiving security fixes at the end of this year. 
- We use `strawberry-graphql` for testing and it does not support python 3.6
